### PR TITLE
correct the bug when running Filter with PCA

### DIFF
--- a/tmap/tda/Filter.py
+++ b/tmap/tda/Filter.py
@@ -114,7 +114,7 @@ class PCA(Filters):
         components: The axis of projection. If you use components 0 and 1, this is [0, 1].
     """
 
-    def __init__(self, components=[0, 1], random_state=None, **kwds):
+    def __init__(self, components=[0, 1], metric=Metric(metric="euclidean"), random_state=None, **kwds):
         # PCA only accept raw data and calculate euclidean distance "internally"
         super(PCA, self).__init__(components=components, metric=None)
         self.pca = decomposition.PCA(n_components=max(self.components) + 1, random_state=random_state, **kwds)


### PR DESCRIPTION
class PCA did not set the argument "metric", will lead to unknown argument error. Add the argument to use euclidean distance here.